### PR TITLE
build: introducing the bin/configure script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,8 +74,9 @@ group :development, :test do
 end
 
 group :development do
-  # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem "web-console"
+  gem "colorize" # Add some methods to set color, background color and text effect on console.
+  gem "highline" # A higher level command-line oriented interface.
+  gem "web-console"  # Use console on exceptions pages [https://github.com/rails/web-console]
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       nap
       open4 (~> 1.3)
     colored2 (3.1.2)
+    colorize (1.1.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     cork (0.3.0)
@@ -503,6 +504,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  colorize
   danger
   debug
   devise (~> 4.9, >= 4.9.3)
@@ -510,6 +512,7 @@ DEPENDENCIES
   erb_lint
   factory_bot (~> 6.4.3)
   faker
+  highline
   i18n-tasks (~> 1.0.14)
   importmap-rails
   irelia!

--- a/README.md.example
+++ b/README.md.example
@@ -1,0 +1,20 @@
+My application
+--------------
+
+# Getting started
+
+#### Run the setup script
+
+To setup your development environment and install all dependencies, run the following command:
+
+```console
+bin/setup
+```
+
+#### Start the development environment
+
+This will start the development environment and run Rails at http://localhost:3000.
+
+```console
+bin/dev
+```

--- a/bin/configuration/check_origin_and_setup_kiqr_remote.rb
+++ b/bin/configuration/check_origin_and_setup_kiqr_remote.rb
@@ -1,0 +1,59 @@
+# Get the upstream repository URL.
+origin_url = `git remote get-url origin`.strip
+origin_exists = system('git remote get-url origin > /dev/null 2>&1')
+kiqr_remote_exists = system('git remote get-url kiqr  > /dev/null 2>&1')
+origin_is_kiqr = origin_exists && origin_url.include?("kiqr/kiqr")
+kiqr_remote_url = "git@github.com:kiqr/kiqr.git"
+
+say "🔍  Checking for the 'origin' remote..."
+
+# Check if origin is kiqr/kiqr
+if origin_is_kiqr
+  fail_with_message <<~WARNING
+
+  WARNING: It looks like your 'origin' remote is set to 'github.com/kiqr/kiqr'.
+
+  This suggests that you may have cloned the project directly instead of using the GitHub 'Use this template' function.
+
+  🚨 Running the configure command might break your development environment by renaming branches or remotes in a way that could disrupt the original repository.
+
+  👉 To avoid this, it's strongly recommended to use the GitHub template feature to create a new repository based on this project.
+
+  You can do this by going to the project's GitHub page and clicking the 'Use this template' button.
+  This will ensure you have your own independent repository with its own 'origin' remote.
+
+  If you proceed with the configure command, please be aware of the potential risks.
+  WARNING
+end
+
+# # Check if origin is not set
+unless origin_exists
+  fail_with_message <<~WARNING
+
+    ⚠️  WARNING: It looks like your repository does not have an 'origin' remote configured.
+
+    This suggests that you may have set up this project incorrectly or did not use the GitHub 'Use this template' function.
+
+    🚨 Without an 'origin' remote, you won't be able to push your changes to a remote repository or properly manage the upstream connection.
+
+    👉 To correctly set up your repository, it's strongly recommended to use the GitHub template feature to create a new repository based on this project.
+
+    You can do this by going to the project's GitHub page and clicking the 'Use this template' button.
+    This will create a new repository with the correct 'origin' remote configured, allowing you to push changes and track your own repository history.
+
+    If you proceed with the configure command, please be aware that you may encounter issues with managing your repository.
+    Press Ctrl+C to cancel now if you do not want to proceed.
+  WARNING
+end
+
+
+say "✅  The 'origin' remote is correctly configured."
+say "🔍  Checking for the 'kiqr' remote..."
+
+if kiqr_remote_exists
+  say "✅  The 'kiqr' remote already exists."
+else
+  say "🚨  The 'kiqr' remote does not exist. Adding it now..."
+  run_command("git remote add kiqr #{kiqr_remote_url}")
+  say "✅  The 'kiqr' remote has been added."
+end

--- a/bin/configuration/cleanup_kiqr_files.rb
+++ b/bin/configuration/cleanup_kiqr_files.rb
@@ -1,0 +1,26 @@
+# List of files to delete from your new repository
+files_or_folders_to_delete = [
+  "Dangerfile",
+  ".github/workflows/dangerfile.yml"
+]
+
+# => Remove KIQR development files
+files_or_folders_to_delete.each do |file_or_folder|
+  run_command("rm -rf #{file_or_folder}")
+  say "✅  Removed #{file_or_folder}"
+end
+
+# => Update .gitignore file
+# Read the contents of the .gitignore file
+gitignore_content = File.read(".gitignore")
+
+# Use a regular expression to remove everything between "# => KIQR START" and "# => KIQR END"
+cleaned_content = gitignore_content.gsub(/# => KIQR START[\s\S]*?# KIQR END\n?/, '')
+
+# Write the cleaned content back to the .gitignore file
+File.open(".gitignore", 'w') { |file| file.write(cleaned_content) }
+say "✅  Cleaned up .gitignore"
+
+# => Replace README.md with README.md.example
+run_command("mv README.md.example README.md")
+say "✅  Replaced README.md with README.md.example"

--- a/bin/configuration/utils.rb
+++ b/bin/configuration/utils.rb
@@ -1,0 +1,14 @@
+require "highline"
+require "highline/import"
+require "colorize"
+
+def fail_with_message(message)
+  say message.red
+  exit(1)
+end
+
+# Run system commands and check for success
+def run_command(command)
+  success = system(command)
+  fail_with_message "Error: Command failed - #{command}" unless success
+end

--- a/bin/configure
+++ b/bin/configure
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require "rubygems"
+require "bundler/setup"
+
+require_relative "configuration/utils"
+require_relative "configuration/check_origin_and_setup_kiqr_remote" # This must always be first since it checks the origin remote.
+require_relative "configuration/cleanup_kiqr_files"


### PR DESCRIPTION
Adds a configure script (`bin/configure`) that setups a git remote to the `kiqr/kiqr` repo for future updates, cleans up files used in the development environment of KIQR and replaces the `README.md` with `README.md.example`